### PR TITLE
Use an exit-event to stop openvpn instead of killing it

### DIFF
--- a/Service.cs
+++ b/Service.cs
@@ -272,6 +272,7 @@ namespace OpenVpn
                 config.logAppend ? FileMode.Append : FileMode.Create,
                 FileAccess.Write,
                 FileShare.Read), new UTF8Encoding(false));
+            logFile.AutoFlush = true;
             
             /// SET UP PROCESS START INFO
             string[] procArgs = {
@@ -294,17 +295,6 @@ namespace OpenVpn
                 UseShellExecute = false,
                 /* create_new_console is not exposed -- but we probably don't need it?*/
             };
-            
-            /// SET UP FLUSH TIMER
-            /** .NET has a very annoying habit of taking a very long time to flush
-                output streams **/
-            var flushTimer = new System.Timers.Timer(60000);
-            flushTimer.AutoReset = true;
-            flushTimer.Elapsed += (object source, System.Timers.ElapsedEventArgs e) =>
-                {
-                    logFile.Flush();
-                };
-            flushTimer.Start();
         }
         
         // set exit event so that openvpn will terminate


### PR DESCRIPTION
For previous discussion on this topic see [here](https://github.com/xkjyeah/openvpnserv2/issues/10)

@mattock:  Thanks for testing. The main improvement I see is that log file is not anymore incomplete on exit. Tearing down routes is nice too, but at least for ipv4 it seems routes do disappear even otherwise when the tunnel goes down. Sending exit notifies with --explicit-exit-notify also works now.

Note: The last fixup commit is squashed down for ease of review.