### PR TITLE
Exit the build early if there's an error

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,9 +1,15 @@
 #!/bin/sh
 
 xbuild /p:Configuration=Release "/p:Platform=Any CPU" OpenVpnService.sln 
+if [ "$?" != "0" ]; then exit 1; fi
 xbuild /p:Configuration=Release "/p:Platform=x86" OpenVpnService.sln 
+if [ "$?" != "0" ]; then exit 1; fi
 xbuild /p:Configuration=Release "/p:Platform=x64" OpenVpnService.sln 
+if [ "$?" != "0" ]; then exit 1; fi
 
 xbuild /p:Configuration=Debug "/p:Platform=Any CPU" OpenVpnService.sln 
+if [ "$?" != "0" ]; then exit 1; fi
 xbuild /p:Configuration=Debug "/p:Platform=x86" OpenVpnService.sln 
+if [ "$?" != "0" ]; then exit 1; fi
 xbuild /p:Configuration=Debug "/p:Platform=x64" OpenVpnService.sln 
+if [ "$?" != "0" ]; then exit 1; fi


### PR DESCRIPTION
Improvement on the Linux build script (build.sh).

This terminates the build when an error occurs